### PR TITLE
#6 Add a Save button to 'New Notes' page

### DIFF
--- a/app/src/main/java/com/example/android/notekeeper/MainActivity.kt
+++ b/app/src/main/java/com/example/android/notekeeper/MainActivity.kt
@@ -12,6 +12,8 @@ import kotlinx.android.synthetic.main.content_main.*
 class MainActivity : AppCompatActivity() {
 
     private var notePosition = POSITION_NOT_SET
+    // Index of the new created note
+    private var newNotePosition: Int? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +33,7 @@ class MainActivity : AppCompatActivity() {
     private fun createNote() {
         DataManager.notes.add(NoteInfo())
         notePosition = DataManager.notes.lastIndex
+        newNotePosition = notePosition
     }
 
     private fun displayNote() {
@@ -64,13 +67,25 @@ class MainActivity : AppCompatActivity() {
                 moveNext()
                 true
             }
+            R.id.action_save -> {
+                // Check if you need to delete the new created note
+                if (newNotePosition != null && newNotePosition != notePosition) {
+                    removeNote(newNotePosition!!)
+                }
+                saveNote()
+                finish()
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        saveNote()
+    override fun onBackPressed() {
+        super.onBackPressed()
+        // Check if you need to delete the new created note
+        if (newNotePosition != null) {
+            removeNote(newNotePosition!!)
+        }
     }
 
     private fun saveNote() {
@@ -78,6 +93,14 @@ class MainActivity : AppCompatActivity() {
         note.title = textFieldTitle.text.toString()
         note.text = textFieldNoteContent.text.toString()
         note.course = dropDownCourses.selectedItem as CourseInfo
+    }
+
+    /**
+     * Remove note at specified [index].
+     * @param index Index of the note to be removed
+     */
+    private fun removeNote(index: Int) {
+        DataManager.notes.removeAt(index)
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/res/drawable/ic_save_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_save_white_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="@android:color/white">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -2,6 +2,8 @@
       xmlns:app="http://schemas.android.com/apk/res-auto"
       xmlns:tools="http://schemas.android.com/tools"
       tools:context="com.tomkarho.android.notekeeper.MainActivity">
+    <item android:title="Save" android:id="@+id/action_save"
+          android:icon="@drawable/ic_save_white_24dp" app:showAsAction="always|withText"/>
     <item android:title="Previous" android:id="@+id/action_previous"
           android:icon="@drawable/ic_arrow_previous_white_24dp" app:showAsAction="always|withText"/>
     <item android:title="Next" android:id="@+id/action_next" app:showAsAction="always|withText"


### PR DESCRIPTION
As requested by issue #6, I added a button to save the notes.

![screenshot save button](https://user-images.githubusercontent.com/24210556/60657299-670dad80-9e51-11e9-890f-c6acce3cd454.jpg)

I have modified the saving behavior of a new note or an existing note in the following way:

- By clicking on the button the note is saved, the activity ends and you return to the main list.
- If you go back directly, the note is not saved.